### PR TITLE
Fix mailbox item retrieval not triggering store-item hook

### DIFF
--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -3092,8 +3092,12 @@ void Player::MoveItemToInventory(ItemPosCountVec const& dest, Item* pItem, bool 
     ItemAddedQuestCheck(pItem->GetEntry(), pItem->GetCount());
     UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_RECEIVE_EPIC_ITEM, pItem->GetEntry(), pItem->GetCount());
 
+    uint32 movedCount = pItem ? pItem->GetCount() : 0;
+    
     // store item
     Item* pLastItem = StoreItem(dest, pItem, update);
+    if (pLastItem)
+        sScriptMgr->OnPlayerStoreNewItem(this, pLastItem, movedCount);
 
     // only set if not merged to existed stack (pItem can be deleted already but we can compare pointers any way)
     if (pLastItem == pItem)


### PR DESCRIPTION
### Summary
This makes item moves through MoveItemToInventory (like mailbox attachment retrieval) trigger OnPlayerStoreNewItem. This keeps item-acquisition behavior consistent and fixes missing auto-collection updates on mail items.

### Why
This was needed for `mod-transmog` to capture item collections from mailbox retrieval.