### PR TITLE
feat: Use repeatable statuses for weekly and monthly quests

### DIFF
--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -1674,7 +1674,14 @@ QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
         QuestStatus status = GetQuestStatus(questId);
         if (status == QUEST_STATUS_COMPLETE && !GetQuestRewardStatus(questId))
         {
-            result2 = DIALOG_STATUS_REWARD;
+            if (quest->IsDailyOrWeekly() || quest->IsMonthly())
+            {
+                result2 = DIALOG_STATUS_REWARD_REP;
+            }
+            else
+            {
+                result2 = DIALOG_STATUS_REWARD;
+            }
         }
         else if (status == QUEST_STATUS_INCOMPLETE)
         {
@@ -1715,7 +1722,7 @@ QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
 
                     if (quest->IsRepeatable())
                     {
-                        if (quest->IsDaily())
+                        if (quest->IsDailyOrWeekly() || quest->IsMonthly())
                         {
                             if (isNotLowLevelQuest)
                             {
@@ -1724,17 +1731,6 @@ QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
                             else
                             {
                                 result2 = DIALOG_STATUS_LOW_LEVEL_AVAILABLE_REP;
-                            }
-                        }
-                        else if (quest->IsWeekly() || quest->IsMonthly())
-                        {
-                            if (isNotLowLevelQuest)
-                            {
-                                result2 = DIALOG_STATUS_AVAILABLE;
-                            }
-                            else
-                            {
-                                result2 = DIALOG_STATUS_LOW_LEVEL_AVAILABLE;
                             }
                         }
                         else if (quest->IsAutoComplete())


### PR DESCRIPTION
Currently, daily quests use a blue icon to indicate that they are repeatable.  However, weekly/monthly quests use a yellow icon even though they are classified as repeatable.

Since weekly/monthly quests are considered repeatable (just like daily quests), it makes sense for these to be blue as well.